### PR TITLE
Added target directory to Git exclusion list

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -6,3 +6,4 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+target/


### PR DESCRIPTION
NetBeans 16 (perhaps earlier) now builds to "target" directory by default.